### PR TITLE
問い合わせフォームのリンクを新しいGoogle Formsに差し替え

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
                 <h2>お問い合わせ</h2>
                 <p>清掃活動への参加をお待ちしています</p>
                 <div style="margin-top: 48px;">
-                    <a href="#" class="btn btn-primary" style="display: inline-flex; align-items: center; gap: 12px; font-size: 1.1rem; padding: 20px 40px;" onclick="alert('GoogleFormのURLを設定してください'); return false;">
+                    <a href="https://docs.google.com/forms/d/e/1FAIpQLSeWncbw7LpkN8kcuoPvCmWynpXXP8X5IroCM1H1BxOf4Hi4-Q/viewform?usp=dialog" class="btn btn-primary" style="display: inline-flex; align-items: center; gap: 12px; font-size: 1.1rem; padding: 20px 40px;" target="_blank">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
                         </svg>


### PR DESCRIPTION
問い合わせフォームのリンクを新しいGoogle FormsのURLに差し替えました。

## 変更内容
- index.htmlのお問い合わせボタンを新しいGoogle FormsのURLに更新
- target="_blank"を追加して新しいタブで開くように設定
- プレースホルダーのalertメッセージを削除

Closes #10

Generated with [Claude Code](https://claude.ai/code)